### PR TITLE
Fixed contactCards styling by removing right margin on mobile devices

### DIFF
--- a/styles/modules/ContactCards.module.sass
+++ b/styles/modules/ContactCards.module.sass
@@ -9,6 +9,9 @@
 .col
   &:nth-child(1)
     margin-right: 100px
+  @media(max-width: 541px)
+    &:nth-child(1)
+      margin-right: 0px
   & > *
     margin-bottom: 39px
     @include media(desktop, laptop, tablet)


### PR DESCRIPTION
Это скрин 9 из той переписки с Семеном, где он давал задания (уехал номер телефона).
Телефон смещался на вторую строку из-за отступа справа у ContactCards, который нужен на десктопе. Добавил media query, который убирает отступ при девайсе с шириной экрана <541px.