### PR TITLE
Added a ternary operator to decide whether a list item containing info about in-person modules should be rendered or not

### DIFF
--- a/components/sections/CostOfStudy.tsx
+++ b/components/sections/CostOfStudy.tsx
@@ -88,7 +88,7 @@ const CostOfStudy = ({ programTitle = null, programId = null }) => {
               />{' '}
               дисциплин специализации
             </li>
-            <li>{!at.online && '3 выезднных модуля в Москве'}</li>
+            {!at.online && <li>3 выездных модуля в Москве</li>}
           </ul>
           <div className='note'>*Возможна рассрочка</div>
         </div>


### PR DESCRIPTION
Это скрин 8 из переписки с Семеном - красный буллит визуально стоял перед div.note, который указывает на возможность оплаты в рассрочку.
По итогу это был не буллит div.note, а буллит li, в котором не было текстового контента - сам li рендерился без текста и имел нулевую высоту, но его буллит оставался виден и складывалось впечатление, что он стоит перед div.note.
Вместо опционального отображения текста li поставил опциональный рендер этого li в целом.