### PR TITLE
Fixed language switching link not displaying properly

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -279,13 +279,15 @@ const Header = ({ programs }) => {
                 </Link>
               </li>
 
-              <li>
-                <a href='' className='mobile-lang-toggle'>
-                  {router.pathname === '/' || router.pathname === '/about'
-                    ? setString(lang.linkLang)
-                    : ''}
-                </a>
-              </li>
+              {router.pathname === '/' || router.pathname === '/about' || router.pathname === '/contact' ? 
+                  <li>
+                    <a href='' className='mobile-lang-toggle'>
+                      {setString(lang.linkLang)}
+                    </a>
+                  </li>
+                  :
+                  null
+                }
             </ul>
             <div className='header-logos'>
               <span className='rabo'>


### PR DESCRIPTION
Это скрин 10 - не отображалась ссылка меню для переключения языка сайта.
Ссылка сама рендерилась, но без текстового наполнения. Поэтому у предыдущего li был виден нижний бордер (которого по стилям быть не должно, если он - последний элемент списка), а также виден псевдо-элемент ::after (стрелка вправо) у этой ссылки.
Поменял так, чтобы сам li, содержащий ссылку на свитч языка, рендерился в зависимости от pathname роутера. Также добавил путь '/contact'.