### PR TITLE
Removed contactCards' right margin on mobile devices

### DIFF
--- a/styles/modules/ContactCards.module.sass
+++ b/styles/modules/ContactCards.module.sass
@@ -8,7 +8,8 @@
 
 .col
   &:nth-child(1)
-    margin-right: 100px
+    @include media(desktop, laptop)
+      margin-right: 100px
   & > *
     margin-bottom: 39px
     @include media(desktop, laptop, tablet)


### PR DESCRIPTION
Cleaned up code from my previous pull request, used media mixin instead of a native media query