### PR TITLE
Fixed positioning of close popup button

### DIFF
--- a/components/popups/Loader.tsx
+++ b/components/popups/Loader.tsx
@@ -9,10 +9,10 @@ const Loader = ({ closePopUp = null }) => {
           <SVGLoader />
           <p>Ваша заявка отправляется, пожалуйста, подождите</p>
         </div>
-        <button className='mfp-close' type='button' onClick={closePopUp}>
-          <SVGClose />
-        </button>
       </div>
+      <button className='mfp-close' type='button' onClick={closePopUp}>
+        <SVGClose />
+      </button>
     </div>
   )
 }

--- a/components/popups/Thankyou.tsx
+++ b/components/popups/Thankyou.tsx
@@ -54,10 +54,10 @@ const Thankyou = ({ closePopUp = null, programId, programTitle }) => {
             Ok!
           </button>
         </div>
-        <button className='mfp-close' type='button' onClick={closePopUp}>
-          <SVGClose />
-        </button>
       </div>
+      <button className='mfp-close' type='button' onClick={closePopUp}>
+        <SVGClose />
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
This is a weird one. The buttons have been absolutely positioned relative to popup-modal like they were supposed to be. And yet for some weird reason they positioned relative to popup-content element which by default has position: static.
I beat my head against the wall trying to determine the cause of this problem but was unsuccessful, so I just moved the button outside of the popup-content element.